### PR TITLE
bump go version to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/projectdiscovery/roundrobin
 
-go 1.17
+go 1.18
 
 require github.com/stretchr/testify v1.8.1
 


### PR DESCRIPTION
# Description

- Bump Go Version 1.17 -> 1.18
- Maintenance (go mod tidy)

Skipped Implementation of Generics because it will break existing API 
more details  at https://github.com/projectdiscovery/roundrobin/issues/8#issuecomment-1313680813


closes #8 
